### PR TITLE
Make it work with Ubuntu 18.04

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The RoboCup@Work Central Factory Hub (CFH) can be installed on most Linux distri
 1. Add [Tim Niemueller's PPA](https://launchpad.net/~timn/+archive/ubuntu/clips):
       
         sudo add-apt-repository ppa:timn/clips
-    (Note: This PPA currently only works for Ubuntu 12.04, 12.10 and 14.04.)
+    (Note: This PPA currently only works for Ubuntu 14.04., 16.04 and 18.04)
     
 2. Install the dependencies for both LLSFRB and CFH:
         
@@ -45,6 +45,7 @@ The RoboCup@Work Central Factory Hub (CFH) can be installed on most Linux distri
                              mongodb libzmq3-dev
 
      (Note: Boost 1.54 is specified to avoid causing apt-get broken package problems with ROS. If you are using another version of Boost see Alternative Setup.)
+     (Note: It's also possible to use the package: libboost-all-dev with no broken packages with ROS [at least this holds for Ubuntu Bionic 18.04])
 
 3. Clone this repository:
         

--- a/atwork/examples/client.cpp
+++ b/atwork/examples/client.cpp
@@ -26,6 +26,7 @@
  * OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <iostream>
 #include <protobuf_comm/client.h>
 #include <msgs/AttentionMessage.pb.h>
 

--- a/atwork/examples/peer.cpp
+++ b/atwork/examples/peer.cpp
@@ -26,6 +26,7 @@
  * OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <iostream>
 #include <protobuf_comm/peer.h>
 #include <msgs/BeaconSignal.pb.h>
 

--- a/atwork/tools/atwork-attention-msg-vis.cpp
+++ b/atwork/tools/atwork-attention-msg-vis.cpp
@@ -34,6 +34,7 @@
 
 #define BOOST_DATE_TIME_POSIX_TIME_STD_CONFIG
 
+#include <iostream>
 #include <config/yaml.h>
 
 #include <protobuf_comm/client.h>

--- a/atwork/tools/atwork-benchmark-ctrl.cpp
+++ b/atwork/tools/atwork-benchmark-ctrl.cpp
@@ -27,6 +27,7 @@
  */
 
 #include <algorithm>
+#include <iostream>
 
 #include <config/yaml.h>
 #include <utils/system/argparser.h>

--- a/atwork/tools/atwork-device-ctrl.cpp
+++ b/atwork/tools/atwork-device-ctrl.cpp
@@ -35,6 +35,7 @@
 #define BOOST_DATE_TIME_POSIX_TIME_STD_CONFIG
 
 #include <config/yaml.h>
+#include <iostream>
 
 #include <protobuf_comm/client.h>
 #include <utils/system/argparser.h>

--- a/etc/buildsys/btypes/config_fawkes.mk
+++ b/etc/buildsys/btypes/config_fawkes.mk
@@ -17,5 +17,4 @@ SYSROOT ?=
 
 # Add -DDEBUG_THREADING if you run into threading problems like deadlocks.
 # Read FawkesDebugging in the Fawkes Trac Wiki on how to use it
-CFLAGS_BASE +=	-g -Wall -Werror
-
+CFLAGS_BASE += -g -Wall 

--- a/src/libs/mongodb_log/mongodb.mk
+++ b/src/libs/mongodb_log/mongodb.mk
@@ -31,9 +31,9 @@ ifneq ($(wildcard /usr/include/mongo/client/dbclient.h /usr/local/include/mongo/
     # version number. Therefore, we try to extract the version from the mongo
     # binary and hope for the best.
     ifneq ($(wildcard /usr/bin/mongo /usr/local/bin/mongo),)
-      MONGODB_VERSION_MAJOR = $(shell mongo --version | grep -o "[0-9]\.[0-9]\.[0-9]" | cut -f1 -d\.)
-      MONGODB_VERSION_MINOR = $(shell mongo --version | grep -o "[0-9]\.[0-9]\.[0-9]" | cut -f2 -d\.)
-      MONGODB_VERSION_PATCH = $(shell mongo --version | grep -o "[0-9]\.[0-9]\.[0-9]" | cut -f3 -d\.)
+      MONGODB_VERSION_MAJOR = $(shell mongo --version | grep -vi ssl | grep -o "[0-9]\.[0-9]\.[0-9]" | cut -f1 -d\.)
+      MONGODB_VERSION_MINOR = $(shell mongo --version | grep -vi ssl | grep -o "[0-9]\.[0-9]\.[0-9]" | cut -f2 -d\.)
+      MONGODB_VERSION_PATCH = $(shell mongo --version | grep -vi ssl | grep -o "[0-9]\.[0-9]\.[0-9]" | cut -f3 -d\.)
     endif
 
     CFLAGS_MONGODB  = -DHAVE_MONGODB \

--- a/src/libs/plugin/manager.cpp
+++ b/src/libs/plugin/manager.cpp
@@ -146,10 +146,10 @@ PluginManager::init_pinfo_cache()
 
   DIR *plugin_dir;
   struct dirent* dirp;
-  const char *file_ext = "."SOEXT;
+  const char *file_ext = "." SOEXT;
 
   if ( NULL == (plugin_dir = opendir(PLUGINDIR)) ) {
-    throw Exception(errno, "Plugin directory %s could not be opened", PLUGINDIR);
+    throw Exception( "Plugin directory %s could not be opened", PLUGINDIR);
   }
 
   for (unsigned int i = 0; NULL != (dirp = readdir(plugin_dir)); ++i) {

--- a/src/libs/utils/system/dynamic_module/module.cpp
+++ b/src/libs/utils/system/dynamic_module/module.cpp
@@ -94,9 +94,9 @@ Module::open()
   std::string full_filename = "";
   full_filename = __filename;
   //                                                                .   SOEXT
-  if ( full_filename.find("."SOEXT, 0) != (full_filename.length() - 1 - strlen(FILE_EXTENSION)) ) {
+  if ( full_filename.find("." SOEXT, 0) != (full_filename.length() - 1 - strlen(FILE_EXTENSION)) ) {
     // filename has no proper ending
-    full_filename += "."SOEXT;
+    full_filename += "." SOEXT;
   }
 
   int tflags = 0;

--- a/src/refbox/Makefile
+++ b/src/refbox/Makefile
@@ -23,7 +23,7 @@ include $(BUILDCONFDIR)/llsf_sps/llsf_sps.mk
 include $(BUILDCONFDIR)/mongodb_log/mongodb.mk
 include $(BUILDCONFDIR)/netcomm/netcomm.mk
 
-CFLAGS += $(CFLAGS_CPP11)
+CFLAGS += $(CFLAGS_CPP11) -lpthread
 
 REQ_BOOST_LIBS = thread asio system signals2
 HAVE_BOOST_LIBS = $(call boost-have-libs,$(REQ_BOOST_LIBS))
@@ -50,6 +50,7 @@ ifeq ($(HAVE_PROTOBUF)$(HAVE_LIBMODBUS)$(HAVE_CLIPS)$(HAVE_BOOST_LIBS),1111)
 
   ifeq ($(HAVE_MONGODB),1)
     LIBS_refbox += llsf_mongodb_log
+    LIBS_refbox += mongoclient
   endif
 else
   ifneq ($(HAVE_PROTOBUF),1)


### PR DESCRIPTION
Removing Werror Flag because this code uses deprecated template declaration. 
Fixing: 
- EVP_CIPHER_CTX: newer OpenSSL versions do not expose the struct EVP_CIPHER_CTX. 
- Fixing warnings: C++11 requires a space between literal and string macro 
- Fixing Mongo Version grep and libraries for refbox.